### PR TITLE
v2026.01.18

### DIFF
--- a/Check-DBX.bat
+++ b/Check-DBX.bat
@@ -1,7 +1,7 @@
 @echo off
 where pwsh >nul 2>nul
 if %errorlevel% equ 0 (
-   pwsh -nop -ep bypass -f "%~dp0\Check_DBXUpdate.bin.ps1" %*
+   pwsh -nop -ep bypass -noexit -f "%~dp0\Check_DBXUpdate.bin.ps1" %*
 ) else (
-   powershell -nop -ep bypass -f "%~dp0\Check_DBXUpdate.bin.ps1" %*
+   powershell -nop -ep bypass -noexit -f "%~dp0\Check_DBXUpdate.bin.ps1" %*
 )

--- a/Check-UEFI.bat
+++ b/Check-UEFI.bat
@@ -1,7 +1,7 @@
 @echo off
 where pwsh >nul 2>nul
 if %errorlevel% equ 0 (
-   pwsh -nop -ep bypass -f "%~dp0\Check_UEFI-CA2023.ps1" %*
+   pwsh -nop -ep bypass -noexit -f "%~dp0\Check_UEFI-CA2023.ps1" %*
 ) else (
-   powershell -nop -ep bypass -f "%~dp0\Check_UEFI-CA2023.ps1" %*
+   powershell -nop -ep bypass -noexit -f "%~dp0\Check_UEFI-CA2023.ps1" %*
 )

--- a/Check_DBXUpdate.bin.ps1
+++ b/Check_DBXUpdate.bin.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.01.03
+.VERSION 2026.01.18
 
 .GUID dbcc69b3-3e30-4e71-a1a9-29ef49f06afc
 
@@ -59,7 +59,7 @@ param (
     [string[]]$Paths = @()
 )
 
-$ScriptVersion = '2026.01.03'
+$ScriptVersion = '2026.01.18'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_DBXSVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -108,6 +108,7 @@ function Get-UefiDatabaseSignatures {
         Original Author: Matthew Graeber (@mattifestation)
         Modified By: Jeremiah Cox (@int0x6)
         Modified By: Joel Roth (@nafai)
+        Modified By: garlin (@garlin-cant-code)
         Additional Source: https://gist.github.com/mattifestation/991a0bea355ec1dc19402cef1b0e3b6f
         Additional Source: https://www.powershellgallery.com/packages/SplitDbxContent/1.0
         License: BSD 3-Clause
@@ -163,6 +164,8 @@ function Get-UefiDatabaseSignatures {
         $Filename
     )
 
+    $PSVersion = $PSVersionTable.PSVersion.Major
+
     $SignatureTypeMapping = @{
         'C1C41626-504C-4092-ACA9-41F936934328' = 'EFI_CERT_SHA256_GUID' # Most often used for dbx
         'A5C059A1-94E4-4AA7-87B5-AB155C2BF072' = 'EFI_CERT_X509_GUID'   # Most often used for db
@@ -172,7 +175,12 @@ function Get-UefiDatabaseSignatures {
 
     if ($Filename)
     {
-        $Bytes = Get-Content -Encoding Byte $Filename -ErrorAction Stop
+        if ($PSVersion -gt 5) {
+            $Bytes = Get-Content -AsByteStream $Filename -ErrorAction Stop
+        }
+        else {
+            $Bytes = Get-Content -Encoding Byte $Filename  -ErrorAction Stop
+        }
     }
     elseif ($Variable)
     {
@@ -237,7 +245,12 @@ function Get-UefiDatabaseSignatures {
                 }
 
                 'EFI_CERT_X509_GUID' {
-                    $SignatureData = New-Object Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @(,([Byte[]] $SignatureDataBytes[16..($SignatureDataBytes.Count - 1)]))
+                    try {
+                        $SignatureData = New-Object Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @(,([Byte[]] $SignatureDataBytes[16..($SignatureDataBytes.Count - 1)]))
+                    }
+                    catch {
+                        Write-Host "Skipping an invalid $Variable X509 certificate."
+                    }
                 }
             }
 

--- a/Update-UEFI.bat
+++ b/Update-UEFI.bat
@@ -1,6 +1,6 @@
 @echo off
 if %errorlevel% equ 0 (
-   pwsh -nop -ep bypass -f "%~dp0\Update_UEFI-CA2023.ps" %*
+   pwsh -nop -ep bypass -noexit -f "%~dp0\Update_UEFI-CA2023.ps1" %*
 ) else (
-   powershell -nop -ep bypass -f "%~dp0\Update_UEFI-CA2023.ps" %*
+   powershell -nop -ep bypass -noexit -f "%~dp0\Update_UEFI-CA2023.ps1" %*
 )


### PR DESCRIPTION
1.  Add error handling to _Get-UefiDatabaseSignatures_ function, when calling `New-Object Security.Cryptography.X509Certificates.X509Certificate2`.
2.  _Get-UefiDatabaseSignatures_ function can now read UEFI bin files on PowerShell 6 & 7.
3.  Updated EDK2 Secure Boot binaries to version 1.6.2, on MS GitHub repo.
4.  Improved batch wrapper scripts to use _-noexit_, and fix typo "**Update_UEFI-CA2023.ps**" in _Update-UEFI.bat_.