### PR TITLE
Remove illegal characters from log filenames

### DIFF
--- a/Check_DBXUpdate.bin.ps1
+++ b/Check_DBXUpdate.bin.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.05.08
+.VERSION 2026.05.21
 
 .GUID dbcc69b3-3e30-4e71-a1a9-29ef49f06afc
 
@@ -59,7 +59,7 @@ param (
     [string[]]$Paths = @()
 )
 
-$ScriptVersion = '2026.05.08'
+$ScriptVersion = '2026.05.21'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_SVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -554,18 +554,18 @@ function Compare-DBXSignatureData {
         if ($DBXSignatureData -contains $RequiredSig) {
             $Matched++
 
-            switch ($RequiredSig) {
-                { $_ -match "^$EFI_BOOTMGR_SVN_GUID" } { $SVN_SigCount++ }
-                { $_ -match "^$EFI_CDBOOT_SVN_GUID" }  { $SVN_SigCount++ }
-                { $_ -match "^$EFI_WDSMGR_SVN_GUID" }  { $SVN_SigCount++ }
+            switch -Regex ($RequiredSig) {
+                "^$EFI_BOOTMGR_SVN_GUID"  { $SVN_SigCount++ }
+                "^$EFI_CDBOOT_SVN_GUID"   { $SVN_SigCount++ }
+                "^$EFI_WDSMGR_SVN_GUID"   { $SVN_SigCount++ }
                 default { $EFI_SigCount++ }
              }
         }
         else {
             $RequiredSVN = Get-SignatureDataSVN $RequiredSig
 
-            switch ($RequiredSig) {
-                { $_ -match "^$EFI_BOOTMGR_SVN_GUID" } {
+            switch -Regex ($RequiredSig) {
+                "^$EFI_BOOTMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_BOOTMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -576,7 +576,7 @@ function Compare-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_CDBOOT_SVN_GUID" } {
+                "^$EFI_CDBOOT_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_CDBOOT_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -587,7 +587,7 @@ function Compare-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_WDSMGR_SVN_GUID" } {
+                "^$EFI_WDSMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_WDSMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -690,7 +690,7 @@ if ($Verbose) {
 }
 
 $System = Get-CimInstance -ClassName Win32_ComputerSystem
-$LogFile = '{0}\{1} {2} Check-DBXUpdate.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), $System.Model.ToUpper()
+$LogFile = '{0}\{1} {2} Check-DBXUpdate.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), ($System.Model.ToUpper().Split([IO.Path]::GetInvalidFileNameChars()) -join '_')
 
 if (Test-Path $LogFile) {
     Remove-Item $LogFile -Force

--- a/Check_UEFI-CA2023.ps1
+++ b/Check_UEFI-CA2023.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.05.14
+.VERSION 2026.05.21
 
 .GUID 240507af-7454-491f-8e42-acb2a40ae3ef
 
@@ -77,7 +77,7 @@ param (
     [string[]]$ignored
 )
 
-$ScriptVersion = '2026.05.14'
+$ScriptVersion = '2026.05.21'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_SVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -255,14 +255,16 @@ function Get-HarddiskVolume {
     return $null
 }
 
-function Get-ProductVersion {
+function Get-FileVersion {
     param (
         [Parameter(Mandatory)]
         [string]$File
     )
 
-    $ProductVersion = (Get-Item -LiteralPath $File).VersionInfo.ProductVersion -replace '^10.0.'
-    return $ProductVersion
+    $FileVersionRaw = (Get-Item -LiteralPath $File).VersionInfo.FileVersionRaw
+    $FileVersion = '{0}.{1}' -f $FileVersionRaw.Build, $FileVersionRaw.Revision
+
+    return $FileVersion
 }
 
 function Print-Header {
@@ -575,27 +577,31 @@ function Validate-PFXCert {
         return 'ALLOWED'
     }
 
-    switch ($CertName) {
-        { $_ -match '2011' } {
-            if ($KEK_Certs -contains 'Microsoft Corporation KEK CA 2011' -and $db_Certs -contains $CertName -and $dbx_Certs -notcontains $CertName) {
-               return 'ALLOWED'
-            }
-            else {
-               return 'BANNED'
-            }
-        }
-
-        { $_ -match '2023' } {
-            if ($KEK_Certs -contains 'Microsoft Corporation KEK 2K CA 2023' -and $db_Certs -contains $CertName -and $dbx_Certs -notcontains $CertName) {
-               return 'ALLOWED'
-            }
-            else {
-               return 'BANNED'
+    switch -Regex ($CertName) {
+        '2011' {
+            if ($KEK_Certs -contains 'Microsoft Corporation KEK CA 2011' -and $db_Certs -contains $CertName) {
+                if ($dbx_Certs -contains $CertName) {
+                    return 'BANNED'
+                }
+                else {
+                    return 'ALLOWED'
+                }
             }
         }
 
-        default { return 'UNKNOWN' }
+        '2023' {
+            if ($KEK_Certs -contains 'Microsoft Corporation KEK 2K CA 2023' -and $db_Certs -contains $CertName) {
+                if ($dbx_Certs -contains $CertName) {
+                    return 'BANNED'
+                }
+                else {
+                    return 'ALLOWED'
+                }
+            }
+        }
     }
+
+    return 'UNTRUSTED'
 }
 
 function Check-TrustedPK {
@@ -718,8 +724,8 @@ function Match-DBXSignatureData {
         else {
             $RequiredSVN = Get-SignatureDataSVN $RequiredSig
 
-            switch ($RequiredSig) {
-                { $_ -match "^$EFI_BOOTMGR_SVN_GUID" } {
+            switch -Regex ($RequiredSig) {
+                "^$EFI_BOOTMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_BOOTMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -727,7 +733,7 @@ function Match-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_CDBOOT_SVN_GUID" } {
+                "^$EFI_CDBOOT_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_CDBOOT_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -735,7 +741,7 @@ function Match-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_WDSMGR_SVN_GUID" } {
+                "^$EFI_WDSMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_WDSMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -1077,18 +1083,21 @@ function Validate-BootMgrFile
 
     $PFXCert = Get-PFXCert $BootMgr_File
 
-    if ((Validate-PFXCert $PFXCert) -eq 'BANNED') {
-        '{0}Boot File [{1}] {2} BANNED' -f $Indent, ($PFXCert -replace 'Microsoft Windows '), $Verb
-    }
-    else {
-        $BootMgrEX_File_Hash = (Get-FileHash $BootMgrEX_File).Hash
-        $BootMgr_File_Hash = (Get-FileHash -LiteralPath $BootMgr_File).Hash
-
-        if ($UEFI_SVN -and ($BootMgr_File_Hash -ne $BootMgrEX_File_Hash)) {
-            '{0}{1} [{2}] {3} BANNED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+    switch -Regex (Validate-PFXCert $PFXCert) {
+        'BANNED|UNTRUSTED' {
+            '{0}Boot File [{1}] {2} {3}' -f $Indent, ($PFXCert -replace 'Microsoft Windows '), $Verb, $_
         }
-        else {
-            '{0}{1} [{2}] {3} ALLOWED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+
+        'ALLOWED' {
+            $BootMgrEX_File_Hash = (Get-FileHash $BootMgrEX_File).Hash
+            $BootMgr_File_Hash = (Get-FileHash -LiteralPath $BootMgr_File).Hash
+
+            if ($UEFI_SVN -and ($BootMgr_File_Hash -ne $BootMgrEX_File_Hash)) {
+                '{0}{1} [{2}] {3} BANNED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+            }
+            else {
+                '{0}{1} [{2}] {3} ALLOWED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+            }
         }
     }
 
@@ -1097,10 +1106,10 @@ function Validate-BootMgrFile
         $Indent += $Tab4
 
         if ($BootMgrSVN -ne $null) {
-            "{0}{1}`n{2}File Version: {3}, SVN {4}`n" -f $Indent, $BootMgr_File, $Indent, (Get-ProductVersion $BootMgr_File), $BootMgrSVN
+            "{0}{1}`n{2}File Version: {3}, SVN {4}`n" -f $Indent, $BootMgr_File, $Indent, (Get-FileVersion $BootMgr_File), $BootMgrSVN
         }
         else {
-            "{0}{1}`n{2}File Version: {3}`n" -f $Indent, $BootMgr_File, $Indent, (Get-ProductVersion $BootMgr_File)
+            "{0}{1}`n{2}File Version: {3}`n" -f $Indent, $BootMgr_File, $Indent, (Get-FileVersion $BootMgr_File)
         }
     }
 }
@@ -1120,11 +1129,11 @@ function Check-WIM_BootManager {
         '{0}{1,-13} Boot Manager [Windows UEFI CA 2023] is PRESENT.' -f $Tab8, $WIM_Image
     }
     else {
-        if ($SecureBoot -eq $false -or $dbx_Certs -notcontains 'Microsoft Windows Production PCA 2011') {
-            '{0}{1,-13} Boot Manager [Production PCA 2011] {2} ALLOWED.' -f $Tab8, $WIM_Image, $Verb
+        if ($SecureBoot -and $dbx_Certs -contains 'Microsoft Windows Production PCA 2011') {
+            '{0}{1,-13} Boot Manager [Production PCA 2011] {2} BANNED.' -f $Tab8, $WIM_Image, $Verb
         }
         else {
-            '{0}{1,-13} Boot Manager [Production PCA 2011] {2} BANNED.' -f $Tab8, $WIM_Image, $Verb
+            '{0}{1,-13} Boot Manager [Production PCA 2011] {2} ALLOWED.' -f $Tab8, $WIM_Image, $Verb
         }
     }
 }
@@ -1522,15 +1531,26 @@ $ScriptBlock = {
     }
 
     $EFI_Device = & bcdedit /enum '{bootmgr}' | Select-String 'device'
-    
-    if ($EFI_Device -match 'Harddisk') {
-        $EFI_Path = '\\.\{0}\EFI' -f ($EFI_Device -split '\\')[-1]
-    }
-    else {
-        $DriveLetter = ($EFI_Device -split '=')[-1]
-        $null = (& mountvol $DriveLetter /l) -match '({.*})'
-    
-        $EFI_Path = '{0}\EFI' -f (Get-HarddiskVolume $Matches[0])
+
+    switch -Regex ($EFI_Device) {
+        'Harddisk' {
+            $EFI_Path = '\\.\{0}\EFI' -f ($EFI_Device -split '\\')[-1]
+        }
+
+        '[A-Z]:' {
+            $DriveLetter = ($EFI_Device -split '=')[-1]
+            $null = (& mountvol $DriveLetter /l) -match '({.*})'
+
+            $EFI_Path = '{0}\EFI' -f (Get-HarddiskVolume $Matches[0])
+        }
+
+        # Worst case fallback
+        default {
+            $SystemDisk = (Get-CimInstance -Namespace 'Root\CIMv2' -Query 'SELECT * FROM Win32_DiskPartition' | where { $_.Type -eq 'GPT: System' }).DiskIndex
+            $GUID = (Get-Partition -DiskNumber $SystemDisk | Where-Object { $_.Type -eq 'System' }).Guid
+
+            $EFI_Path = '{0}EFI' -f (Get-Volume_DevicePath $GUID)
+        }
     }
 
     $BootMgrEX_File = "$env:SystemRoot\Boot\EFI_EX\bootmgfw_EX.efi"
@@ -1736,7 +1756,7 @@ $ScriptBlock = {
 
 if ($Log) {
     $System = Get-CimInstance -ClassName Win32_ComputerSystem
-    $LogFile = '{0}\{1} {2} Check-UEFI.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), $System.Model.ToUpper()
+    $LogFile = '{0}\{1} {2} Check-UEFI.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), ($System.Model.ToUpper().Split([IO.Path]::GetInvalidFileNameChars()) -join '_')
 
     & $ScriptBlock | Tee-Object $LogFile
     "`nLog file saved as `"{0}`"`n" -f $LogFile

--- a/README_UEFI.TXT
+++ b/README_UEFI.TXT
@@ -1,31 +1,34 @@
 Manual installation of [Windows OEM Devices PK]
 ===============================================
 
-1. Shutdown Windows, and enter your UEFI's Secure Boot menu.
+1. WARNING: Disable Windows Hello PIN for all users, before proceeding.  Otherwise TPM will detect
+   recent changes to Secure Boot and invalidate your PIN.
 
-2. Enter "PK Options / Enroll PK / Enroll PK Using File" or "Key Management / PK Management / Set Key".
+2. Shutdown Windows, and enter your UEFI's Secure Boot menu.
+
+3. Enter "PK Options / Enroll PK / Enroll PK Using File" or "Key Management / PK Management / Set Key".
    The menu options may be different for your BIOS.
 
    - Browse the system drive's EFI partition
    - Enter the <EFI> folder
    - Enter the <Certs> sub-folder
 
-3. Find the file "WindowsOEMDevicesPK.der".  Add the certificate.
+4. Find the file "WindowsOEMDevicesPK.der".  Add the certificate.
 
-4. Enter "KEK Options / Enroll KEK / Enroll KEK Using File" or "Key Management / KEK Management / Append Key".
+5. Enter "KEK Options / Enroll KEK / Enroll KEK Using File" or "Key Management / KEK Management / Append Key".
    The menu options may be different for your BIOS.
 
    - Browse the system drive's EFI partition
    - Enter the <EFI> folder
    - Enter the <Updates> sub-folder
 
-5. Find the file "Microsoft Corporation KEK 2K CA 2023.der".  Add this certificate.
+6. Find the file "Microsoft Corporation KEK 2K CA 2023.der".  Add this certificate.
 
-6. Save changes and exit.
+7. Save changes and exit.
 
-7. Leave the BIOS in Custom Mode.
+8. Leave the BIOS in Custom Mode.
 
-8. Start Windows, and re-run the 'Update-UEFI_CA2023.ps1' script.
+9. Start Windows, and re-run the 'Update-UEFI_CA2023.ps1' script.
 
 
 Manual installation of [KEK 2K CA 2023]
@@ -51,21 +54,32 @@ Manual installation of [KEK 2K CA 2023]
 NOTES FOR HP PC's
 =================
 
-HP Sure Start Secure Boot Keys Protection
+Please check if your PC has HP Sure Start, which reverts any "unauthorized" changes to the Secure Boot keys.
+Failure to follow these instructions may result in a boot loop.
 
-"With this setting at the factory default of enable, HP Sure Start provides enhanced protection of the
-secure boot databases and keys used by BIOS to verify the integrity and authenticity of the OS bootloader
-before launching it at boot. When set to "Disable", only standard UEFI secure boot variable protection
-is used, and no backup copy is kept by the HP Sure Start subsystem."
+Disabling HP Sure Start Secure Boot Keys Protection:
+
+1. Disable Secure Boot and restart into BIOS.  A BIOS Admin password may be needed before you're allowed to use this option.
+
+2. Disable Sure Start Secure Boot Keys Protection and restart BIOS.
+
+3. Enable Clear Secure Boot Keys and restart Windows.  Run this step *only* if you have to be in Setup Mode, otherwise skip.
+
+4. Run the update script.  Ignore any signature violation errors from writing the PK (in Setup Mode).
+
+5. Enable Secure Boot and restart Windows.
+
+6. Enable Sure Start.
 
 
 NOTES FOR DELL PC's
 ===================
 
-If manual key enrollment reports the KEK .der file is the wrong format, then manual enrollment will not
-work for this BIOS version.
-
-You must use the "Delete All Keys" option in the UEFI menu, and run the 'Update_UEFI-CA2023.ps1' script.
-
-For more instructions on the Dell BIOS menus, please read:
+For instructions on the Dell BIOS menus, please read:
 https://www.dell.com/support/kbdoc/en-us/000368610/how-to-update-secure-boot-active-database-from-bios
+
+If manual key enrollment reports the KEK .der file is the wrong format, then manual enrollment will not work for
+this BIOS version.
+
+Use the "Delete All Keys" option in the UEFI menu, before running the 'Update_UEFI-CA2023.ps1' script.
+

--- a/Update_UEFI-CA2023.ps1
+++ b/Update_UEFI-CA2023.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.05.14
+.VERSION 2026.05.21
 
 .GUID 7c7848ed-3952-4726-8f23-8644881c2c91
 
@@ -92,7 +92,7 @@ param (
     [string[]]$ignored
 )
 
-$ScriptVersion = '2026.05.14'
+$ScriptVersion = '2026.05.21'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_SVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -646,8 +646,8 @@ function Match-DBXSignatureData {
         else {
             $RequiredSVN = Get-SignatureDataSVN $RequiredSig
 
-            switch ($RequiredSig) {
-                { $_ -match "^$EFI_BOOTMGR_SVN_GUID" } {
+            switch -Regex ($RequiredSig) {
+                "^$EFI_BOOTMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_BOOTMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -655,7 +655,7 @@ function Match-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_CDBOOT_SVN_GUID" } {
+                "^$EFI_CDBOOT_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_CDBOOT_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -663,7 +663,7 @@ function Match-DBXSignatureData {
                     }
                 }
 
-                { $_ -match "^$EFI_WDSMGR_SVN_GUID" } {
+                "^$EFI_WDSMGR_SVN_GUID" {
                     $CurrentSVN = Get-SecureBootUEFI_SVN $EFI_WDSMGR_SVN_GUID
 
                     if ($CurrentSVN -ge $RequiredSVN) {
@@ -963,6 +963,10 @@ function Append-SecureBootSignedFile {
             # Incorrect authentication data: 0xC0000022
             '0xC0000022' {
                 Write-Host 'Wrong signature for this UEFI variable.' -Foreground Red
+
+                if ($SecureBoot -and $Variable -eq 'dbx') {
+                    Write-Host "Try disabling Legacy CSM support and Secure Boot, before running the script."
+                }
             }
 
             # Unexpected Result, status error: 0xC000000D
@@ -1250,14 +1254,14 @@ $ScriptBlock = {
     }
 
     $EFI_Device = & bcdedit /enum '{bootmgr}' | Select-String 'device'
-    
+
     if ($EFI_Device -match 'Harddisk') {
         $EFI_Path = '\\.\{0}\EFI' -f ($EFI_Device -split '\\')[-1]
     }
     else {
         $DriveLetter = ($EFI_Device -split '=')[-1]
         $null = (& mountvol $DriveLetter /l) -match '({.*})'
-    
+
         $EFI_Path = '{0}\EFI' -f (Get-HarddiskVolume $Matches[0])
     }
 
@@ -1490,9 +1494,9 @@ $ScriptBlock = {
                     $Label = $Volume.FileSystemLabel
 
                     if (Test-Path $EFI_BootMgr) {
-                        $EFI_BootMgr_Hash = (Get-FileHash -LiteralPath $EFI_BootMgr).Hash
+                        $EFI_BootMgr_File_Hash = (Get-FileHash -LiteralPath $EFI_BootMgr).Hash
 
-                        if ($EFI_BootMgr_Hash -ne $BootMgrEX_File_Hash) {
+                        if ($EFI_BootMgr_File_Hash -ne $BootMgrEX_File_Hash) {
                             $BCD = "$EFI_Path\Microsoft\Boot\BCD"
                             $Backup_BCD = "$env:TEMP\BCD.BAK"
 
@@ -1582,7 +1586,7 @@ $ScriptBlock = {
 
 if ($Log) {
     $System = Get-CimInstance -ClassName Win32_ComputerSystem
-    $LogFile = '{0}\{1} {2} Update-UEFI.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), $System.Model.ToUpper()
+    $LogFile = '{0}\{1} {2} Update-UEFI.log' -f $PSScriptRoot, (Get-Date -Format 'yyyy-MM-dd'), ($System.Model.ToUpper().Split([IO.Path]::GetInvalidFileNameChars()) -join '_')
 
     & $ScriptBlock | Tee-Object $LogFile
     "`nLog file saved as `"{0}`"`n" -f $LogFile

--- a/Versions.txt
+++ b/Versions.txt
@@ -1,8 +1,8 @@
 Run ".\Check_DBXUpdate.bin.ps1 -version"
-    Check_DBXUpdate.bin.ps1 version (2026.05.08)
+    Check_DBXUpdate.bin.ps1 version (2026.05.21)
 
 Run ".\Check_UEFI-CA2023.ps1 -version"
-    Check_UEFI-CA2023.ps1 version (2026.05.14)
+    Check_UEFI-CA2023.ps1 version (2026.05.21)
 
 Run ".\Update_UEFI-CA2023.ps1 -version"
-    Update_UEFI-CA2023.ps1 version (2026.05.14)
+    Update_UEFI-CA2023.ps1 version (2026.05.21)


### PR DESCRIPTION
The log file's filename is derived from the Win32_ComputerSystem model name. Replace any characters which are considered illegal for a Windows filename.