### PR TITLE
[BUG] Hotfix for bad comparison of boot manager's SVN version

### DIFF
--- a/Check_UEFI-CA2023.ps1
+++ b/Check_UEFI-CA2023.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.05.21
+.VERSION 2026.05.27
 
 .GUID 240507af-7454-491f-8e42-acb2a40ae3ef
 
@@ -77,7 +77,7 @@ param (
     [string[]]$ignored
 )
 
-$ScriptVersion = '2026.05.21'
+$ScriptVersion = '2026.05.27'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_SVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -1082,6 +1082,7 @@ function Validate-BootMgrFile
     )
 
     $PFXCert = Get-PFXCert $BootMgr_File
+    $BootMgrSVN = Get-BootManagerSVN $BootMgr_File
 
     switch -Regex (Validate-PFXCert $PFXCert) {
         'BANNED|UNTRUSTED' {
@@ -1092,17 +1093,16 @@ function Validate-BootMgrFile
             $BootMgrEX_File_Hash = (Get-FileHash $BootMgrEX_File).Hash
             $BootMgr_File_Hash = (Get-FileHash -LiteralPath $BootMgr_File).Hash
 
-            if ($UEFI_SVN -and ($BootMgr_File_Hash -ne $BootMgrEX_File_Hash)) {
-                '{0}{1} [{2}] {3} BANNED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+            if (($BootMgr_File_Hash -eq $BootMgrEX_File_Hash) -or ($UEFI_SVN -and [version]$BootMgrSVN -ge [version]$UEFI_SVN)) {
+                '{0}{1} [{2}] {3} ALLOWED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
             }
             else {
-                '{0}{1} [{2}] {3} ALLOWED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
+                '{0}{1} [{2}] {3} BANNED.' -f $Indent, $Label, ($PFXCert -replace 'Microsoft Windows '), $Verb
             }
         }
     }
 
     if ($Verbose) {
-        $BootMgrSVN = Get-BootManagerSVN $BootMgr_File
         $Indent += $Tab4
 
         if ($BootMgrSVN -ne $null) {

--- a/Update_UEFI-CA2023.ps1
+++ b/Update_UEFI-CA2023.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 2026.05.21
+.VERSION 2026.05.27
 
 .GUID 7c7848ed-3952-4726-8f23-8644881c2c91
 
@@ -92,7 +92,7 @@ param (
     [string[]]$ignored
 )
 
-$ScriptVersion = '2026.05.21'
+$ScriptVersion = '2026.05.27'
 
 # https://github.com/microsoft/secureboot_objects/blob/main/Archived/dbx_info_msft_4_09_24_svns.csv
 $EFI_BOOTMGR_SVN_GUID = '01612B139DD5598843AB1C185C3CB2EB92'
@@ -578,6 +578,23 @@ function Get-DBXUpdateSVN {
     }
 
     return (Get-SignatureDataSVN $($SignatureData))
+}
+
+function Get-BootManagerSVN {
+    param (
+        [Parameter(Mandatory)]
+        [string]$BootMgr_File
+    )
+
+    # Get-SecureBootSVN is only available in W11 Feb 2026 Preview or later releases
+    try {
+        $BootMgrSVN = (Get-SecureBootSVN -BootManagerPath $BootMgr_File).BootManagerSVN
+    }
+    catch {
+        $BootMgrSVN = $null
+    }
+
+    return $BootMgrSVN
 }
 
 function Match-DBXSignatureData {
@@ -1468,7 +1485,9 @@ $ScriptBlock = {
         $BootMgrEX_File_Hash = (Get-FileHash $BootMgrEX_File).Hash
         $BootMgr_File_Hash = (Get-FileHash -LiteralPath $BootMgr_File).Hash
 
-        if ($BootMgr_File_Hash -ne $BootMgrEX_File_Hash) {
+        $BootMgrSVN = Get-BootManagerSVN $BootMgr_File
+
+        if (($BootMgr_File_Hash -ne $BootMgrEX_File_Hash) -and ([version]$BootMgrSVN -lt [version]$UEFI_SVN)) {
             Update-EFI_BootManager
             $UEFI_Updated = $true
         }

--- a/Versions.txt
+++ b/Versions.txt
@@ -2,7 +2,7 @@ Run ".\Check_DBXUpdate.bin.ps1 -version"
     Check_DBXUpdate.bin.ps1 version (2026.05.21)
 
 Run ".\Check_UEFI-CA2023.ps1 -version"
-    Check_UEFI-CA2023.ps1 version (2026.05.21)
+    Check_UEFI-CA2023.ps1 version (2026.05.27)
 
 Run ".\Update_UEFI-CA2023.ps1 -version"
-    Update_UEFI-CA2023.ps1 version (2026.05.21)
+    Update_UEFI-CA2023.ps1 version (2026.05.2)


### PR DESCRIPTION
Report DB/DBX certs missing their validated KEK as "UNTRUSTED" instead of "BANNED" introduced a new bug incorrectly reporting a matching SVN as "BANNED".