### PR TITLE
Create a block list of PC models that have reported UFI issues with "bricking"

### DIFF
--- a/Check_UEFI-CA2023.ps1
+++ b/Check_UEFI-CA2023.ps1
@@ -1362,7 +1362,7 @@ $ScriptBlock = {
     }
 
     switch -Regex ($System.Model) {
-       '*LENOVO*M700*' { $Unsafe_Model = $true }
+       ".*LENOVO.*M700.*" { $Unsafe_Model = $true }
     }
 
     if ($Verbose -or $HP_NotSupported -or $Unsafe_Model) {


### PR DESCRIPTION
Created a new bug by using the wrong "*" regex. /sigh