### PR TITLE
Get-ItemPropertyValue is missing "-ErrorAction Stop"

### DIFF
--- a/Check_UEFI-CA2023.ps1
+++ b/Check_UEFI-CA2023.ps1
@@ -1738,7 +1738,7 @@ $ScriptBlock = {
 
     if ($BootMedia) {
         try {
-            $InstallDir = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Macrium\RescuePE' -Name 'InstallDir'
+            $InstallDir = Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Macrium\RescuePE' -Name 'InstallDir' -ErrorAction Stop
         }
         catch {
             $InstallDir = "$env:SystemDrive\boot"


### PR DESCRIPTION
This code doesn't correctly handle when the reg key is undefined.