### PR TITLE
Issue #129 fix for bcdedit & bcdboot execution path doesn't work on 32-bit Windows

### DIFF
--- a/Check_BootMedia.ps1
+++ b/Check_BootMedia.ps1
@@ -155,13 +155,13 @@ if ($Quiet) {
     $Verbose = $false
 }
 
-if ([Environment]::Is64BitProcess) {
-    $UpdatesFolder = "$env:SystemRoot\System32\SecureBootUpdates"
-    $bcdedit = 'bcdedit'
-}
-else {
+if ($env:PROCESSOR_ARCHITEW6432) {
     $UpdatesFolder = "$env:SystemRoot\SysNative\SecureBootUpdates"
     $bcdedit = "$env:SystemRoot\SysNative\bcdedit"
+}
+else {
+    $UpdatesFolder = "$env:SystemRoot\System32\SecureBootUpdates"
+    $bcdedit = 'bcdedit'
 }
 
 switch ($env:PROCESSOR_ARCHITECTURE) {

--- a/Check_UEFI-CA2023.ps1
+++ b/Check_UEFI-CA2023.ps1
@@ -114,13 +114,13 @@ if ($PSBoundParameters['Verbose']) {
     $VerbosePreference = 'SilentlyContinue'
 }
 
-if ([Environment]::Is64BitProcess) {
-    $UpdatesFolder = "$env:SystemRoot\System32\SecureBootUpdates"
-    $bcdedit = 'bcdedit'
-}
-else {
+if ($env:PROCESSOR_ARCHITEW6432) {
     $UpdatesFolder = "$env:SystemRoot\SysNative\SecureBootUpdates"
     $bcdedit = "$env:SystemRoot\SysNative\bcdedit"
+}
+else {
+    $UpdatesFolder = "$env:SystemRoot\System32\SecureBootUpdates"
+    $bcdedit = 'bcdedit'
 }
 
 $System = Get-CimInstance -ClassName Win32_ComputerSystem

--- a/Update_UEFI-CA2023.ps1
+++ b/Update_UEFI-CA2023.ps1
@@ -157,13 +157,13 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     exit 0
 }
 
-if ([Environment]::Is64BitProcess) {
-    $bcdedit = 'bcdedit'
-    $bcdboot = 'bcdboot'
-}
-else {
+if ($env:PROCESSOR_ARCHITEW6432) {
     $bcdedit = "$env:SystemRoot\SysNative\bcdedit"
     $bcdboot = "$env:SystemRoot\SysNative\bcdboot"
+}
+else {
+    $bcdedit = 'bcdedit'
+    $bcdboot = 'bcdboot'
 }
 
 $System = Get-CimInstance -ClassName Win32_ComputerSystem


### PR DESCRIPTION
Issue 129 (Missing 32-bit execution path for bcdedit and bcdboot in different script locations) doesn't actually work on 32-bit Windows.